### PR TITLE
readme & submodules: replace URL git proto with HTTP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "nuttx"]
 	path = nuttx
-	url = git@github.com:radupascale/nuttx.git
+	url = https://github.com/radupascale/nuttx.git
 	branch = hectorwatch
 [submodule "nuttx-apps"]
 	path = nuttx-apps
-	url = git@github.com:radupascale/nuttx-apps.git
+	url = https://github.com/radupascale/nuttx-apps.git
 	branch = hectorwatch

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Cloning the repository
 
 ```bash
-git clone --recurse-submodules git@github.com:radupascale/hectorwatch-nuttx.git
+git clone --recurse-submodules https://github.com/radupascale/hectorwatch-nuttx
 cd hectorwatch-nuttx
 git submodule update --remote
 ```


### PR DESCRIPTION
Please don't use git/ssh URLs for public repositories, makes it harder than necessary to clone the repo, requiring a SSH key to be setup with GitHub (especially if using submodules, see [1] for a local dev. recommendation)!

[1] https://stackoverflow.com/questions/50282837/using-ssh-vs-https-with-github-submodules